### PR TITLE
Resolve phpunit init coding error

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -26,7 +26,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once("$CFG->libdir/externallib.php");
+use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_multiple_structure;
+use core_external\external_single_structure;
+use core_external\external_value;
+
 require_once("$CFG->dirroot/mod/oublog/locallib.php");
 
 class mod_oublog_external extends external_api {
@@ -50,7 +55,7 @@ class mod_oublog_external extends external_api {
             return \local_oudataload\users::get_webservice_identifier_parameter();
         } else {
             return new external_single_structure([
-                'username' => new \external_value(PARAM_ALPHANUM, 'Moodle username'),
+                'username' => new external_value(PARAM_ALPHANUM, 'Moodle username'),
             ]);
         }
     }


### PR DESCRIPTION
```
root@6a2ca8501c58:/var/www/he-43# vendor/bin/phpunit --testsuite=mod_oublog_testsuite
Moodle 4.3+ (Build: 20231027), d4681208e7a30afdcca0c052ee0802dd43e7dd65
Php: 8.1.24, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.4.12-060412-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

.......S.............S...........S.......S.....................  63 / 122 ( 51%)
..........................................................S     122 / 122 (100%)

Time: 00:39.146, Memory: 107.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 122, Assertions: 1339, Skipped: 5.
```